### PR TITLE
fix: change the table of equations from empty strings to underscores

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -357,7 +357,7 @@
     set block(breakable: true)
     if it.block and not it.has("label") [
       #counter(math.equation).update(v => v - 1)
-      #math.equation(it.body, block: true, numbering: none)#label("")
+      #math.equation(it.body, block: true, numbering: none)#label("_")
     ] else {
       it
     }


### PR DESCRIPTION
我刚刚接触 typst，发现编译 example 时此处出错，原因是新版本的 typst 不再支持空标签